### PR TITLE
Exchange flow plugin with new one

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ module.exports = {
   extends: "eslint:recommended",
   plugins: ["flow-vars", "babel"],
   rules: {
-    "flow-vars/define-flow-type": "warn",
-    "flow-vars/use-flow-type": "warn",
+    "flowtype/define-flow-type": "warn",
+    "flowtype/use-flow-type": "warn",
     quotes: ["error", "double"],
     "no-var": "error",
     "keyword-spacing": "error",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "babel-eslint": "^6.0.0",
     "eslint-plugin-babel": "^3.0.0",
-    "eslint-plugin-flow-vars": "^0.4.0"
+    "eslint-plugin-flowtype": "^2.19.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -10,10 +10,9 @@
     "url": "https://github.com/babel/babel/tree/master/packages/eslint-config-babel"
   },
   "main": "index.js",
-  "dependencies": {
-    "babel-eslint": "^6.0.0",
+  "peerDependencies": {
     "eslint-plugin-babel": "^3.0.0",
-    "eslint-plugin-flowtype": "^2.19.0"
+    "eslint-plugin-flowtype": "^2.4.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "main": "index.js",
   "peerDependencies": {
+    "babel-eslint": "^6.0.0",
     "eslint-plugin-babel": "^3.0.0",
     "eslint-plugin-flowtype": "^2.4.0"
   },


### PR DESCRIPTION
This also makes the plugins peerDependencies, because installing them as dependencies would only work with npm@3 and not with 2, so we would anyway always need to install them in the project.