### PR TITLE
better indent switch, iife, multiline functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,21 @@ module.exports = {
     "comma-dangle": "off",
     "consistent-return": "off",
     curly: "off",
-    "indent": ["error", 2],
+    indent: ["error", 2, {
+      SwitchCase: 1,
+      outerIIFEBody: 1,
+      FunctionDeclaration: {
+        parameters: 1,
+        body: 1,
+      },
+      FunctionExpression: {
+        parameters: 1,
+        body: 1,
+      },
+      CallExpression: {
+        parameters: 1,
+      }
+    }],
     "linebreak-style": ["error", "unix"],
     "key-spacing": "off",
     "keyword-spacing": "error",


### PR DESCRIPTION
For iife and parameters of multiline function expressions/ function calls this activates the check that these are indented correctly, before the check was inactive.

For switch-case:
Before
```js
switch() {
case '': break;
}
```

After
```js
switch() {
  case '': break;
}
```