### PR TITLE
peerDeps: remove eslint-plugin-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "main": "index.js",
   "peerDependencies": {
     "babel-eslint": "^7.0.0",
-    "eslint-plugin-babel": "^4.0.0",
     "eslint-plugin-flowtype": "^2.4.0"
   },
   "scripts": {


### PR DESCRIPTION
This PR removes eslint-plugin-babel from devDependencies as it is no longer required by the config.