### PR TITLE
Add func-call-spacing rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
     "comma-spacing": "error",
     "consistent-return": "off",
     curly: "off",
+    "func-call-spacing": "error",
     indent: ["error", 2, {
       SwitchCase: 1,
       outerIIFEBody: 1,


### PR DESCRIPTION
Disallows
```js
foo ();

foo
();

```

http://eslint.org/docs/rules/func-call-spacing