### PR TITLE
Fix version range for flow plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "index.js",
   "peerDependencies": {
     "babel-eslint": "^7.0.0",
-    "eslint-plugin-flowtype": "^2.4.0"
+    "eslint-plugin-flowtype": ">=2.4.0 <2.30.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
newer versions do not support node <6 anymore 😭
We might not need to do this here but we need to lock all projects to this version range at least.
https://travis-ci.org/babel/babylon/builds/208358091
https://travis-ci.org/babel/babel-loader/jobs/208352796

Thats why dropping node version should not be done in minor/patch versions. 

//cc @gajus