### PR TITLE
Update babel-eslint peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "main": "index.js",
   "peerDependencies": {
-    "babel-eslint": "^7.0.0",
+    "babel-eslint": "^7.0.0 || ^8.0.0-alpha",
     "eslint-plugin-flowtype": "^2.4.0"
   },
   "scripts": {


### PR DESCRIPTION
Suppress:

```sh
npm ERR! peerinvalid The package babel-eslint@8.0.0-alpha.12 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer eslint-config-babel@7.0.1 wants babel-eslint@^7.0.0
```